### PR TITLE
Added new subscriberConfigurator options (1. auto create durable named queue and 2. create non-durable test named queue for multiple subscriber tests) + work on test code

### DIFF
--- a/Sources/Binding/RabbitMQ.IntegrationTests/LargeBinaryTransferTest.cs
+++ b/Sources/Binding/RabbitMQ.IntegrationTests/LargeBinaryTransferTest.cs
@@ -103,7 +103,7 @@ namespace RabbitMQ.IntegrationTests
 
             wait.Should().BeTrue();
 
-            A.CallTo(() => _processorFake.LargeData(A<Blob>._)).MustHaveHappened(Repeated.Like(i => i == 1));
+            A.CallTo(() => _processorFake.LargeData(A<Blob>._)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 }

--- a/Sources/Binding/RabbitMQ.IntegrationTests/RabbitMQ.IntegrationTests.csproj
+++ b/Sources/Binding/RabbitMQ.IntegrationTests/RabbitMQ.IntegrationTests.csproj
@@ -42,15 +42,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\FakeItEasy.1.17.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=3.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>

--- a/Sources/Binding/RabbitMQ.IntegrationTests/TransactionalOneWayTest.cs
+++ b/Sources/Binding/RabbitMQ.IntegrationTests/TransactionalOneWayTest.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Transactions;
 using FakeItEasy;
 using FluentAssertions;
+using FluentAssertions.Specialized;
 using MessageBus.Binding.RabbitMQ;
 using NUnit.Framework;
 using RabbitMQ.IntegrationTests.ContractsAndServices;
@@ -172,7 +173,7 @@ namespace RabbitMQ.IntegrationTests
             }).MustHaveHappened();
         }
         
-        [Test, ExpectedException(typeof(FaultException))]
+        [Test]
         public void RabbitMQBinding_TransactionalDispatching_ExceptionIfTransactionalChannelUsedOutOfTheTransactionScope()
         {
             IOneWayService channel = _channelFactory.CreateChannel();
@@ -199,9 +200,7 @@ namespace RabbitMQ.IntegrationTests
             Assert.IsTrue(wait, "Service were not being invoked");
 
             // Same channel instance can't be used outsode transaction scope
-            channel.Say(new Data());
-
-            Assert.Fail("Same channel instance can't be used outsode transaction scope");
+            ((Action)(() => channel.Say(new Data()))).ShouldThrow<FaultException>();
         }
     }
 }

--- a/Sources/Binding/RabbitMQ.IntegrationTests/packages.config
+++ b/Sources/Binding/RabbitMQ.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FakeItEasy" version="1.17.0" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.2.1" targetFramework="net40" requireReinstallation="True" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net451" />
 </packages>

--- a/Sources/Binding/RabbitMQ.UnitTests/RabbitMQ.UnitTests.csproj
+++ b/Sources/Binding/RabbitMQ.UnitTests/RabbitMQ.UnitTests.csproj
@@ -38,15 +38,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=3.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>

--- a/Sources/Binding/RabbitMQ.UnitTests/packages.config
+++ b/Sources/Binding/RabbitMQ.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="3.2.1" targetFramework="net40" requireReinstallation="True" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net451" />
 </packages>

--- a/Sources/Binding/ZeroMQ.IntegrationTests/PubSubMessagingTest.cs
+++ b/Sources/Binding/ZeroMQ.IntegrationTests/PubSubMessagingTest.cs
@@ -19,6 +19,9 @@ namespace ZeroMQ.IntegrationTests
         [TestFixtureSetUp]
         public void SetUp()
         {
+            if (IntPtr.Size != 8)
+                Assert.Inconclusive("Please run this test in x64");
+
             _fake = A.Fake<IPublicationService>();
 
             _host = new ServiceHost(new PublicationService(_fake));

--- a/Sources/Binding/ZeroMQ.IntegrationTests/PushPullMessagingTest.cs
+++ b/Sources/Binding/ZeroMQ.IntegrationTests/PushPullMessagingTest.cs
@@ -19,6 +19,9 @@ namespace ZeroMQ.IntegrationTests
         [TestFixtureSetUp]
         public void SetUp()
         {
+            if (IntPtr.Size != 8)
+                Assert.Inconclusive("Please run this test in x64");
+
             _fake = A.Fake<IPublicationService>();
 
             _host = new ServiceHost(new PublicationService(_fake));

--- a/Sources/Binding/ZeroMQ.IntegrationTests/ZeroMQ.IntegrationTests.csproj
+++ b/Sources/Binding/ZeroMQ.IntegrationTests/ZeroMQ.IntegrationTests.csproj
@@ -45,8 +45,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\FakeItEasy.1.17.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Sources/Binding/ZeroMQ.IntegrationTests/packages.config
+++ b/Sources/Binding/ZeroMQ.IntegrationTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="clrzmq-x64" version="2.2.5" targetFramework="net40" />
   <package id="FakeItEasy" version="1.17.0" targetFramework="net40" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnit" version="3.6.0" targetFramework="net40" />
 </packages>

--- a/Sources/Core.API/ISubscriberConfigurator.cs
+++ b/Sources/Core.API/ISubscriberConfigurator.cs
@@ -58,7 +58,7 @@ namespace MessageBus.Core.API
         /// Enable mutliple subscribers to enlist to the same queue instead of using exclusive queue even if the queue is non-durable
         /// </summary>
         /// <returns></returns>
-        ISubscriberConfigurator UseNonDurableNamedQueue(string queueNameSuffix);
+        ISubscriberConfigurator UseNonDurableNamedQueue(string queueName);
 
         /// <summary>
         /// Specify transactional delivery of the messages. If exception will be thrown on subscribed action message will be returned to the queue.

--- a/Sources/Core.API/ISubscriberConfigurator.cs
+++ b/Sources/Core.API/ISubscriberConfigurator.cs
@@ -46,6 +46,21 @@ namespace MessageBus.Core.API
         ISubscriberConfigurator UseDurableQueue(string queueName, bool createBindings);
 
         /// <summary>
+        /// Specify durable queue name to listen for the messages.
+        /// </summary>
+        /// <param name="queueName">Durable queue name</param>
+        /// <param name="createBindings">Specify if message bindings should be created</param>
+        /// <param name="autoCreate">Specify if queue should be automatically created</param>
+        /// <returns></returns>
+        ISubscriberConfigurator UseDurableQueue(string queueName, bool createBindings, bool autoCreate);
+
+        /// <summary>
+        /// Enable mutliple subscribers to enlist to the same queue instead of using exclusive queue even if the queue is non-durable
+        /// </summary>
+        /// <returns></returns>
+        ISubscriberConfigurator UseNonDurableNamedQueue(string queueNameSuffix);
+
+        /// <summary>
         /// Specify transactional delivery of the messages. If exception will be thrown on subscribed action message will be returned to the queue.
         /// </summary>
         /// <returns></returns>

--- a/Sources/Core.IntegrationTest/BusDurableTests.cs
+++ b/Sources/Core.IntegrationTest/BusDurableTests.cs
@@ -11,6 +11,7 @@ namespace Core.IntegrationTest
     public class BusDurableTests
     {
         private const string QueueName = "DurableTestQueue";
+        private const string AutomaticallyCreatedQueueName = "AutomaticDurableTestQueue";
 
         [TestFixtureSetUp]
         public void Initialize()
@@ -20,7 +21,7 @@ namespace Core.IntegrationTest
                 using (IRouteManager routeManager = bus.CreateRouteManager())
                 {
                     routeManager.CreateQueue(QueueName, true, false, CreateQueueSettings.Default);
-                    
+
                     routeManager.QueueBindMessage<ImportiantData>(QueueName);
                 }
             }
@@ -34,6 +35,7 @@ namespace Core.IntegrationTest
                 using (IRouteManager routeManager = bus.CreateRouteManager())
                 {
                     routeManager.DeleteQueue(QueueName);
+                    routeManager.DeleteQueue(AutomaticallyCreatedQueueName);
                 }
             }
         }
@@ -42,7 +44,7 @@ namespace Core.IntegrationTest
         public void Bus_DurableBus_SubscribesAfterPublishing_MessagesShouldBeReceived()
         {
             ImportiantData data = new ImportiantData { Info = "Valuable information" };
-            
+
             // Dispatch message
             using (var bus = new MessageBus.Core.RabbitMQBus())
             {
@@ -66,6 +68,62 @@ namespace Core.IntegrationTest
 
                             ev.Set();
                         });
+
+                    subscriber.Open();
+
+                    bool wait = ev.WaitOne(TimeSpan.FromSeconds(5));
+
+                    wait.Should().BeTrue();
+                }
+            }
+
+            expected.Should().NotBeNull();
+
+            expected.ShouldBeEquivalentTo(data);
+        }
+
+        [Test]
+        public void Bus_DurableBus_AutomaticalyCreated_SubscribesAfterPublishing_MessagesShouldBeReceived()
+        {
+            // Create a subscriber in order to create queue and bindings then dispose of it
+            // queue and bindings should remain
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (ISubscriber subscriber = bus.CreateSubscriber(c =>
+                    c.UseDurableQueue(AutomaticallyCreatedQueueName, true, true)))
+                {
+                    subscriber.Subscribe((Action<ImportiantData>)(p => { }));
+                    subscriber.Open();
+                    subscriber.Close();
+                }
+            }
+
+            ImportiantData data = new ImportiantData { Info = "Valuable information" };
+
+            // Dispatch message
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (IPublisher publisher = bus.CreatePublisher())
+                {
+                    publisher.Send(data);
+                }
+            }
+
+            ImportiantData expected = null;
+            ManualResetEvent ev = new ManualResetEvent(false);
+
+            // Second bus subscribes to message after it was dispatched and should receive it
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (ISubscriber subscriber = bus.CreateSubscriber(c =>
+                    c.UseDurableQueue(AutomaticallyCreatedQueueName, true, true)))
+                {
+                    subscriber.Subscribe<ImportiantData>(p =>
+                    {
+                        expected = p;
+
+                        ev.Set();
+                    });
 
                     subscriber.Open();
 

--- a/Sources/Core.IntegrationTest/BusFailedDeliveryTest.cs
+++ b/Sources/Core.IntegrationTest/BusFailedDeliveryTest.cs
@@ -23,9 +23,9 @@ namespace Core.IntegrationTest
             {
                 using (IPublisher publisher = bus.CreatePublisher(c => c.SetMandatoryDelivery().UseErrorHandler(this)))
                 {
-                    Person person = new Person {Id = 5};
+                    UndeliverablePerson person = new UndeliverablePerson { Id = 5};
 
-                    BusMessage<Person> busMessage = new BusMessage<Person>
+                    BusMessage<UndeliverablePerson> busMessage = new BusMessage<UndeliverablePerson>
                         {
                             Data = person
                         };
@@ -46,15 +46,20 @@ namespace Core.IntegrationTest
                     _text.Should().Be("NO_ROUTE");
 
                     _message.BusId.Should().Be(bus.BusId);
-                    _message.Name.Should().Be("Person");
+                    _message.Name.Should().Be("UndeliverablePerson");
                     _message.Sent.Should().BeCloseTo(DateTime.Now, 2000);
-                    _message.Data.Should().BeOfType<Person>();
+                    _message.Data.Should().BeOfType<UndeliverablePerson>();
 
                     _message.Headers.OfType<BusHeader>().Should().OnlyContain(header => header.Name == "Header" && header.Value == "Value");
 
                     person.ShouldBeEquivalentTo(_message.Data);
                 }
             }
+        }
+
+        // Created a specific class for these tests to prevent bindings from other tests from interfering
+        public class UndeliverablePerson : Person
+        {
         }
 
         public void DeliveryFailed(int errorCode, string text, RawBusMessage message)

--- a/Sources/Core.IntegrationTest/Core.IntegrationTests.csproj
+++ b/Sources/Core.IntegrationTest/Core.IntegrationTests.csproj
@@ -42,12 +42,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\FakeItEasy.1.17.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=3.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Sources/Core.IntegrationTest/Core.IntegrationTests.csproj
+++ b/Sources/Core.IntegrationTest/Core.IntegrationTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="BlobTransferTest.cs" />
     <Compile Include="BusAnnotatedSubscriptionTests.cs" />
     <Compile Include="BusAsyncRpcCommunicationTest.cs" />
+    <Compile Include="QueueNonDurableTests.cs" />
     <Compile Include="BusDurableTests.cs" />
     <Compile Include="BusFailedDeliveryTest.cs" />
     <Compile Include="BusMessageTests.cs" />

--- a/Sources/Core.IntegrationTest/QueueNonDurableTests.cs
+++ b/Sources/Core.IntegrationTest/QueueNonDurableTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Threading;
+using System.Runtime.Serialization;
+using FluentAssertions;
+using MessageBus.Core.API;
+using NUnit.Framework;
+
+namespace Core.IntegrationTest
+{
+    [TestFixture]
+    public class QueueNonDurableTests
+    {
+        private const string NonDurableTestQueueSuffix = "NonDurableTests";
+
+        [Test]
+        public void Queue_NonDurableQueue_SubscribesAfterPublishing_MessagesShouldNotBeReceived()
+        {
+            // Create a subscriber in order to create queue and bindings then dispose of it
+            // queue and bindings should remain
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (ISubscriber subscriber = bus.CreateSubscriber(c => { }))
+                {
+                    subscriber.Subscribe((Action<NonImportantData>)(p => { }));
+                    subscriber.Open();
+                    subscriber.Close();
+                }
+            }
+
+            NonImportantData data = new NonImportantData { Info = "Non-Valuable information" };
+
+            // Dispatch message
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (IPublisher publisher = bus.CreatePublisher())
+                {
+                    publisher.Send(data);
+                }
+            }
+
+            NonImportantData expected = null;
+            ManualResetEvent ev = new ManualResetEvent(false);
+
+            // Second bus subscribes to message after it was dispatched and should receive it
+            using (var bus = new MessageBus.Core.RabbitMQBus())
+            {
+                using (ISubscriber subscriber = bus.CreateSubscriber(c => { }))
+                {
+                    subscriber.Subscribe<NonImportantData>(p =>
+                    {
+                        expected = p;
+
+                        ev.Set();
+                    });
+
+                    subscriber.Open();
+
+                    bool wait = ev.WaitOne(TimeSpan.FromSeconds(5));
+
+                    wait.Should().BeFalse();
+                }
+            }
+
+            expected.Should().BeNull();
+        }
+
+        [Test]
+        public void Queue_NonDurableQueue_TwoExclusiveSubscribers_BothShouldGetMessage()
+        {
+            NonImportantData data = new NonImportantData { Info = "Non-Valuable information" };
+
+            NonImportantData expected1 = null;
+            NonImportantData expected2 = null;
+            ManualResetEvent ev1 = new ManualResetEvent(false);
+            ManualResetEvent ev2 = new ManualResetEvent(false);
+            bool wait1;
+            bool wait2;
+            IBus subscriberBus = null;
+            ISubscriber subscriber1 = null, subscriber2 = null;
+
+            try
+            {
+                subscriberBus = new MessageBus.Core.RabbitMQBus();
+                subscriber1 = subscriberBus.CreateSubscriber(c => { });
+                subscriber1.Subscribe<NonImportantData>(p =>
+                {
+                    expected1 = p;
+                    ev1.Set();
+                });
+                subscriber1.Open();
+
+                subscriber2 = subscriberBus.CreateSubscriber(c => { });
+                subscriber2.Subscribe<NonImportantData>(p =>
+                {
+                    expected2 = p;
+                    ev2.Set();
+                });
+                subscriber2.Open();
+
+                // Dispatch message
+                using (var bus = new MessageBus.Core.RabbitMQBus())
+                {
+                    using (IPublisher publisher = bus.CreatePublisher())
+                    {
+                        publisher.Send(data);
+                    }
+                }
+                
+                wait1 = ev1.WaitOne(TimeSpan.FromMilliseconds(100));
+                wait2 = ev2.WaitOne(TimeSpan.FromMilliseconds(100));
+            }
+            finally
+            {
+                subscriber2?.Dispose();
+                subscriber1?.Dispose();
+                subscriberBus?.Dispose();
+            }
+
+            wait1.Should().BeTrue();
+            wait2.Should().BeTrue();
+
+            expected1.Should().NotBeNull();
+            expected1.ShouldBeEquivalentTo(data);
+
+            expected2.Should().NotBeNull();
+            expected2.ShouldBeEquivalentTo(data);
+        }
+
+        [Test]
+        public void Queue_NonDurableQueue_TwoSharedQueueSubscribers_OneShouldGetMessage()
+        {
+            NonImportantData data = new NonImportantData { Info = "Non-Valuable information" };
+
+            NonImportantData expected1 = null;
+            NonImportantData expected2 = null;
+            ManualResetEvent ev1 = new ManualResetEvent(false);
+            ManualResetEvent ev2 = new ManualResetEvent(false);
+            bool wait1;
+            bool wait2;
+            IBus subscriberBus = null;
+            ISubscriber subscriber1 = null, subscriber2 = null;
+
+            try
+            {
+                subscriberBus = new MessageBus.Core.RabbitMQBus();
+                subscriber1 = subscriberBus.CreateSubscriber(c => c.UseNonDurableNamedQueue(NonDurableTestQueueSuffix));
+                subscriber1.Subscribe<NonImportantData>(p =>
+                {
+                    expected1 = p;
+                    ev1.Set();
+                });
+                subscriber1.Open();
+
+                subscriber2 = subscriberBus.CreateSubscriber(c => c.UseNonDurableNamedQueue(NonDurableTestQueueSuffix));
+                subscriber2.Subscribe<NonImportantData>(p =>
+                {
+                    expected2 = p;
+                    ev2.Set();
+                });
+                subscriber2.Open();
+
+                // Dispatch message
+                using (var bus = new MessageBus.Core.RabbitMQBus())
+                {
+                    using (IPublisher publisher = bus.CreatePublisher())
+                    {
+                        publisher.Send(data);
+                    }
+                }
+
+                wait1 = ev1.WaitOne(TimeSpan.FromMilliseconds(100));
+                wait2 = ev2.WaitOne(TimeSpan.FromMilliseconds(100));
+            }
+            finally
+            {
+                subscriber2?.Dispose();
+                subscriber1?.Dispose();
+                subscriberBus?.Dispose();
+            }
+
+            // Wait for reset events to timeout
+            Thread.Sleep(500);
+
+            wait1.ShouldBeEquivalentTo(!wait2);
+
+            if (wait1)
+            {
+                expected2.Should().BeNull();
+                expected1.Should().NotBeNull();
+                expected1.ShouldBeEquivalentTo(data);
+            }
+            else
+            {
+                expected1.Should().BeNull();
+                expected2.Should().NotBeNull();
+                expected2.ShouldBeEquivalentTo(data);
+            }
+        }
+
+        [DataContract]
+        public class NonImportantData
+        {
+            [DataMember]
+            public string Info { get; set; }
+        }
+    }
+}

--- a/Sources/Core.IntegrationTest/packages.config
+++ b/Sources/Core.IntegrationTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FakeItEasy" version="1.17.0" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.2.1" targetFramework="net40" requireReinstallation="True" />
+  <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net451" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net451" />

--- a/Sources/Core.Proxy.IntegrationTests/Core.Proxy.IntegrationTests.csproj
+++ b/Sources/Core.Proxy.IntegrationTests/Core.Proxy.IntegrationTests.csproj
@@ -48,8 +48,9 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>

--- a/Sources/Core.Proxy.IntegrationTests/packages.config
+++ b/Sources/Core.Proxy.IntegrationTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net451" />
 </packages>

--- a/Sources/Core.SignalR.IntegrationTests/Core.SignalR.IntegrationTests.csproj
+++ b/Sources/Core.SignalR.IntegrationTests/Core.SignalR.IntegrationTests.csproj
@@ -36,8 +36,8 @@
     <Reference Include="Microsoft.AspNet.SignalR.Core">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.2.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -61,6 +61,9 @@
       <Project>{e314af95-5622-4138-8897-4cf80026e1af}</Project>
       <Name>Core.SignalR</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Sources/Core.SignalR.IntegrationTests/packages.config
+++ b/Sources/Core.SignalR.IntegrationTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
 </packages>

--- a/Sources/Core.UnitTests/Core.UnitTests.csproj
+++ b/Sources/Core.UnitTests/Core.UnitTests.csproj
@@ -38,15 +38,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=3.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.3.2.1\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Sources/Core.UnitTests/packages.config
+++ b/Sources/Core.UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="3.2.1" targetFramework="net40" requireReinstallation="True" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
 </packages>

--- a/Sources/Core2/RabbitMQBus.cs
+++ b/Sources/Core2/RabbitMQBus.cs
@@ -250,13 +250,13 @@ namespace MessageBus.Core
                 {
                     if (configurator.Durable)
                     {
-                        // TODO: [Danny] exclusive?
+                        // exclusive: Can only be accessed by the current connection. (default false)
+                        // https://github.com/EasyNetQ/EasyNetQ/wiki/The-Advanced-API
                         model.QueueDeclare(configurator.QueueName, true, false, false, new Dictionary<string, object>());
                     }
                     else
                     {
-                        // TODO: [Danny] exclusive?
-                        model.QueueDeclare(configurator.QueueName, false, false, true, new Dictionary<string, object>());
+                        model.QueueDeclare(configurator.QueueName, false, true, true, new Dictionary<string, object>());
                     }
                 }
 

--- a/Sources/Core2/RabbitMQBus.cs
+++ b/Sources/Core2/RabbitMQBus.cs
@@ -242,12 +242,28 @@ namespace MessageBus.Core
 
         private static string CreateQueue(IModel model, SubscriberConfigurator configurator)
         {
+            QueueDeclareOk queueDeclare;
+
             if (!string.IsNullOrEmpty(configurator.QueueName))
             {
+                if (configurator.AutoCreate)
+                {
+                    if (configurator.Durable)
+                    {
+                        // TODO: [Danny] exclusive?
+                        model.QueueDeclare(configurator.QueueName, true, false, false, new Dictionary<string, object>());
+                    }
+                    else
+                    {
+                        // TODO: [Danny] exclusive?
+                        model.QueueDeclare(configurator.QueueName, false, false, true, new Dictionary<string, object>());
+                    }
+                }
+
                 return configurator.QueueName;
             }
 
-            QueueDeclareOk queueDeclare = model.QueueDeclare("", false, true, true, new Dictionary<string, object>());
+            queueDeclare = model.QueueDeclare("", false, true, true, new Dictionary<string, object>());
 
             return queueDeclare.QueueName;
         }

--- a/Sources/Core2/SubscriberConfigurator.cs
+++ b/Sources/Core2/SubscriberConfigurator.cs
@@ -200,14 +200,13 @@ namespace MessageBus.Core
             return this;
         }
 
-        public ISubscriberConfigurator UseNonDurableNamedQueue(string queueNameSuffix)
+        public ISubscriberConfigurator UseNonDurableNamedQueue(string queueName)
         {
             _durable = false;
 
             _autoCreate = true;
 
-            _queueName = "serviceBus.gen-" + System.Environment.MachineName
-                + "." + System.Diagnostics.Process.GetCurrentProcess().Id + "." + queueNameSuffix;
+            _queueName = queueName;
 
             return this;
         }

--- a/Sources/Core2/SubscriberConfigurator.cs
+++ b/Sources/Core2/SubscriberConfigurator.cs
@@ -13,16 +13,18 @@ namespace MessageBus.Core
         private IErrorSubscriber _errorSubscriber;
         private ITrace _trace;
         private IExceptionFilter _exceptionFilter = new NullExceptionFilter();
-        private string _queueName = "";
+        private string _queueName = string.Empty;
         private bool _receiveSelfPublish;
         private bool _neverReply;
         private string _replyExchange;
         private bool _transactionalDelivery;
         private ushort _prefetch;
         private string _exchange;
-        private string _routingKey = "";
-        private string _consumerTag = "";
+        private string _routingKey = string.Empty;
+        private string _consumerTag = string.Empty;
         private bool _createBindings = true;
+        private bool _autoCreate = true;
+        private bool _durable = true;
         private JsonSerializerSettings _settings = new JsonSerializerSettings
         {
             Formatting = Formatting.None
@@ -43,10 +45,12 @@ namespace MessageBus.Core
         {
             get { return _queueName; }
         }
+
         public string Exchange
         {
             get { return _exchange; }
         }
+
         public string RoutingKey
         {
             get { return _routingKey; }
@@ -128,6 +132,16 @@ namespace MessageBus.Core
             get { return _createBindings; }
         }
 
+        public bool Durable
+        {
+            get { return _durable; }
+        }
+
+        public bool AutoCreate
+        {
+            get { return _autoCreate; }
+        }
+
         public ISubscriberConfigurator UseBufferManager(BufferManager bufferManager)
         {
             _bufferManager = bufferManager;
@@ -151,16 +165,49 @@ namespace MessageBus.Core
 
         public ISubscriberConfigurator UseDurableQueue(string queueName)
         {
+            _durable = true;
+
             _queueName = queueName;
+
+            _autoCreate = false;
 
             return this;
         }
 
         public ISubscriberConfigurator UseDurableQueue(string queueName, bool createBindings)
         {
+            _durable = true;
+
             _queueName = queueName;
 
             _createBindings = createBindings;
+
+            _autoCreate = false;
+
+            return this;
+        }
+
+        public ISubscriberConfigurator UseDurableQueue(string queueName, bool createBindings, bool autoCreate)
+        {
+            _durable = true;
+
+            _queueName = queueName;
+
+            _createBindings = createBindings;
+
+            _autoCreate = autoCreate;
+
+            return this;
+        }
+
+        public ISubscriberConfigurator UseNonDurableNamedQueue(string queueNameSuffix)
+        {
+            _durable = false;
+
+            _autoCreate = true;
+
+            _queueName = "serviceBus.gen-" + System.Environment.MachineName
+                + "." + System.Diagnostics.Process.GetCurrentProcess().Id + "." + queueNameSuffix;
 
             return this;
         }

--- a/Sources/MessageBus.sln
+++ b/Sources/MessageBus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Binding", "Binding", "{D06C3A7A-7D2A-4710-AB4B-1EEA88C293CB}"
 EndProject


### PR DESCRIPTION
Hi,

I've added new subscriberConfigurator options:
1. auto create durable named queue
2. create non-durable test named queue for multiple subscriber tests)

In addition, I've consolidated the NuGets for the tests and fixed the test code that was broken by the NuGet updates.

Regards,
Danny Varod.
